### PR TITLE
Repair description in package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cache",
   "version": "2.3.1",
-  "description": "Simple caching object without ttl",
+  "description": "Simple caching object with TTL",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
The `description` in the `package.json` file does not match the title in the `README.md` file and the available features.